### PR TITLE
3 seconds is better, methinks

### DIFF
--- a/blink.ino
+++ b/blink.ino
@@ -20,5 +20,5 @@ void loop() {
   digitalWrite(led, HIGH);   // turn the LED on (HIGH is the voltage level)
   delay(3000);               // wait for a second
   digitalWrite(led, LOW);    // turn the LED off by making the voltage LOW
-  delay(2000);               // wait for a second
+  delay(4000);               // wait for a second
 }

--- a/blink.ino
+++ b/blink.ino
@@ -1,24 +1,24 @@
 /*
   Blink
   Turns on an LED on for one second, then off for one second, repeatedly.
- 
+
   This example code is in the public domain.
  */
- 
+
 // Pin 13 has an LED connected on most Arduino boards.
 // give it a name:
 int led = 13;
 
 // the setup routine runs once when you press reset:
-void setup() {                
+void setup() {
   // initialize the digital pin as an output.
-  pinMode(led, OUTPUT);     
+  pinMode(led, OUTPUT);
 }
 
 // the loop routine runs over and over again forever:
 void loop() {
   digitalWrite(led, HIGH);   // turn the LED on (HIGH is the voltage level)
-  delay(1000);               // wait for a second
+  delay(3000);               // wait for a second
   digitalWrite(led, LOW);    // turn the LED off by making the voltage LOW
   delay(2000);               // wait for a second
 }

--- a/blink.ino
+++ b/blink.ino
@@ -18,7 +18,7 @@ void setup() {
 // the loop routine runs over and over again forever:
 void loop() {
   digitalWrite(led, HIGH);   // turn the LED on (HIGH is the voltage level)
-  delay(3000);               // wait for a second
+  delay(3000);               // wait for 3 seconds
   digitalWrite(led, LOW);    // turn the LED off by making the voltage LOW
-  delay(4000);               // wait for a second
+  delay(4000);               // wait for 4 seconds
 }


### PR DESCRIPTION
A discussion with the local community, the users of the device, reveals that three seconds is the preferred blink delay.